### PR TITLE
Throw away the first measurement

### DIFF
--- a/process_gk_stats.py
+++ b/process_gk_stats.py
@@ -50,6 +50,10 @@ with open(sys.argv[1]) as f:
         gk_total_num_packets.append(sum(cur_num_packets))
         gk_total_num_bytes.append(sum(cur_num_bytes))
 
+# Throw away the first measurement.
+gk_total_num_packets = gk_total_num_packets[1:]
+gk_total_num_bytes = gk_total_num_bytes[1:]
+
 #
 # Process client measurements.
 #


### PR DESCRIPTION
This is to deal with the XIA server experiment setup:
when Gatekeeper boots, the GK blocks have already started
the measurement while the bots haven't launched yet.
This can lead to under-estimation on throughput
depending on when the bots are fully launched.

This patch solves this issue.